### PR TITLE
Support Beat Saber 1.18.*

### DIFF
--- a/HeadDistanceTravelled.sln
+++ b/HeadDistanceTravelled.sln
@@ -8,11 +8,14 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Release_1_18_0|Any CPU = Release_1_18_0|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release_1_18_0|Any CPU.ActiveCfg = Release_1_18_0|Any CPU
+		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release_1_18_0|Any CPU.Build.0 = Release_1_18_0|Any CPU
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/HeadDistanceTravelled.sln
+++ b/HeadDistanceTravelled.sln
@@ -7,15 +7,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeadDistanceTravelled", "He
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|1.18.0 = Debug|1.18.0
 		Debug|Any CPU = Debug|Any CPU
-		Release_1_18_0|Any CPU = Release_1_18_0|Any CPU
+		Release|1.18.0 = Release|1.18.0
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Debug|1.18.0.ActiveCfg = Debug|x64
+		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Debug|1.18.0.Build.0 = Debug|x64
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release_1_18_0|Any CPU.ActiveCfg = Release_1_18_0|Any CPU
-		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release_1_18_0|Any CPU.Build.0 = Release_1_18_0|Any CPU
+		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release|1.18.0.ActiveCfg = Release|1.18.0
+		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release|1.18.0.Build.0 = Release|1.18.0
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CD360C2-9F6C-4F96-99E0-872242229F1D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/HeadDistanceTravelled/HeadDistanceTravelled.csproj
+++ b/HeadDistanceTravelled/HeadDistanceTravelled.csproj
@@ -17,6 +17,7 @@
     <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
     <BeatSaberDir>$(LocalRefsDir)</BeatSaberDir>
     <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
+    <BeatSeberTargetVersion>1_20_0</BeatSeberTargetVersion>
     <!--<PathMap>$(AppOutputBase)=X:\$(AssemblyName)\</PathMap>-->
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -31,7 +32,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DefineConstants>VER_1_20_0</DefineConstants>
+	<DefineConstants>VER_1_20_0</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
@@ -39,6 +40,13 @@
   <PropertyGroup Condition="'$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
     <DisableZipRelease>True</DisableZipRelease>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release_1_18_0'">
+    <BeatSeberTargetVersion>1_18_0</BeatSeberTargetVersion>
+	<DefineConstants>VER_1_18_0</DefineConstants>
+    <OutputPath>bin\Release_1_18_0\</OutputPath>
+    <Optimize>true</Optimize>
+	<WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BeatmapCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -142,7 +150,7 @@
     <Compile Include="Views\HMDDistanceFloatingScreen.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="manifest.json" />
+    <EmbeddedResource Include="manifest.1_20_0.json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
@@ -156,6 +164,8 @@
     <EmbeddedResource Include="Views\HDTSettingView.bsml">
       <DependentUpon>HDTSettingView.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="manifest.1_18_0.json" />
+    <EmbeddedResource Include="manifest.json" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks">
@@ -165,4 +175,7 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>copy /Y $(ProjectDir)manifest.$(BeatSeberTargetVersion).json $(ProjectDir)manifest.json</PreBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/HeadDistanceTravelled/HeadDistanceTravelled.csproj
+++ b/HeadDistanceTravelled/HeadDistanceTravelled.csproj
@@ -22,17 +22,24 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;VER_1_20_0</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-	<DefineConstants>VER_1_20_0</DefineConstants>
+    <DefineConstants>VER_1_20_0</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|1.18.0'">
+    <BeatSeberTargetVersion>1_18_0</BeatSeberTargetVersion>
+    <DefineConstants>VER_1_18_0</DefineConstants>
+    <OutputPath>bin\Release\1_18_0\</OutputPath>
+    <Optimize>true</Optimize>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
@@ -40,13 +47,6 @@
   <PropertyGroup Condition="'$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
     <DisableZipRelease>True</DisableZipRelease>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release_1_18_0'">
-    <BeatSeberTargetVersion>1_18_0</BeatSeberTargetVersion>
-	<DefineConstants>VER_1_18_0</DefineConstants>
-    <OutputPath>bin\Release_1_18_0\</OutputPath>
-    <Optimize>true</Optimize>
-	<WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BeatmapCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/HeadDistanceTravelled/HeadDistanceTravelled.csproj
+++ b/HeadDistanceTravelled/HeadDistanceTravelled.csproj
@@ -150,7 +150,7 @@
     <Compile Include="Views\HMDDistanceFloatingScreen.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="manifest.1_20_0.json" />
+    <None Include="manifest.1_20_0.json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
@@ -164,7 +164,7 @@
     <EmbeddedResource Include="Views\HDTSettingView.bsml">
       <DependentUpon>HDTSettingView.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="manifest.1_18_0.json" />
+    <None Include="manifest.1_18_0.json" />
     <EmbeddedResource Include="manifest.json" />
   </ItemGroup>
   <ItemGroup>

--- a/HeadDistanceTravelled/Installers/HDTGameInstaller.cs
+++ b/HeadDistanceTravelled/Installers/HDTGameInstaller.cs
@@ -1,5 +1,8 @@
 ﻿using HeadDistanceTravelled.Configuration;
 using HeadDistanceTravelled.Views;
+#if VER_1_18_0
+using SiraUtil;
+#endif
 using Zenject;
 
 namespace HeadDistanceTravelled.Installers

--- a/HeadDistanceTravelled/Installers/HDTMenuInstaller.cs
+++ b/HeadDistanceTravelled/Installers/HDTMenuInstaller.cs
@@ -1,4 +1,7 @@
 ﻿using HeadDistanceTravelled.Views;
+#if VER_1_18_0
+using SiraUtil;
+#endif
 using Zenject;
 
 namespace HeadDistanceTravelled.Installers

--- a/HeadDistanceTravelled/Plugin.cs
+++ b/HeadDistanceTravelled/Plugin.cs
@@ -26,8 +26,13 @@ namespace HeadDistanceTravelled
             Log.Info("HeadDistanceTravelled initialized.");
             Configuration.PluginConfig.Instance = conf.Generated<Configuration.PluginConfig>();
             Log.Debug("Config loaded");
+#if VER_1_18_0
+            zenjector.OnMenu<HDTMenuInstaller>();
+            zenjector.OnGame<HDTGameInstaller>(true).OnlyForStandard();
+#else
             zenjector.Install<HDTMenuInstaller>(Location.Menu);
             zenjector.Install<HDTGameInstaller>(Location.Player);
+#endif
         }
 
         [OnStart]

--- a/HeadDistanceTravelled/manifest.1_18_0.json
+++ b/HeadDistanceTravelled/manifest.1_18_0.json
@@ -1,0 +1,13 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/bsmg/BSIPA-MetadataFileSchema/master/Schema.json",
+  "id": "HeadDistanceTravelled",
+  "name": "HeadDistanceTravelled",
+  "author": "",
+  "version": "0.0.2",
+  "description": "",
+  "gameVersion": "1.18.0",
+  "dependsOn": {
+    "BSIPA": "^4.2.0",
+    "SiraUtil": "^2.5.8"
+  }
+}

--- a/HeadDistanceTravelled/manifest.1_20_0.json
+++ b/HeadDistanceTravelled/manifest.1_20_0.json
@@ -1,0 +1,13 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/bsmg/BSIPA-MetadataFileSchema/master/Schema.json",
+  "id": "HeadDistanceTravelled",
+  "name": "HeadDistanceTravelled",
+  "author": "",
+  "version": "0.0.2",
+  "description": "",
+  "gameVersion": "1.20.0",
+  "dependsOn": {
+    "BSIPA": "^4.2.2",
+    "SiraUtil": "^3.0.5"
+  }
+}


### PR DESCRIPTION
Fixed #3 

## Summary
Beat Saber `1.18.*` に対応したプラットフォーム設定及びそのコードを追加

## Changes
- `1.18.0` Platform をソリューション・プロジェクトに追加
  - これが選ばれた場合、`VER_1_18_0` 定数が宣言されるよう変更
  - 規定の `AnyCPU` が選ばれた場合、`VER_1_20_0` 定数が宣言されるよう変更
- `VER_1_18_0` が定義されているとき、`SiraUtil 2.5.8` 及び `BSIPA 4.2.0`以降 に依存して動作するようコードを変更
- 対象の Beat Saber バージョンに対応した `manifest_{version}.json` を個別に作成し、PostBuild イベントにおいてそれを `manifest.json` としてコピーするよう修正
  - これにより、ビルド構成のプラットフォームを切り替えることにより `1.20.0` / `1.18.*` をターゲットとしたアセンブリをビルドできる
- リリースビルド時、下記の通りに成果物が出力される
  - `AnyCPU`（デフォルト）では `1.20.0` 用のアセンブリが `Release` ディレクトリ下に作成される
  - `1.18.0` では `1.18.*` 用のアセンブリが `Release\1_18_3` ディレクトリ下に作成される

## Tests
- `1.18.0` / `AnyCPU` (1.20.0) 両 Platform を選択したとき、それぞれ正しく対象の `manifest.{version}.json` がコピーされ、アセンブリに含まれることを ILSpy により確認
- `1.18.*` 向けのアセンブリが Beat Saber `1.18.3` で正常に動作することを手動で確認（テストプレイ済み）