### PR TITLE
Prevent false detection of `fpfc` mode

### DIFF
--- a/HeadDistanceTravelled/HeadDistanceTravelledController.cs
+++ b/HeadDistanceTravelled/HeadDistanceTravelledController.cs
@@ -107,7 +107,7 @@ namespace HeadDistanceTravelled
         public void Start()
         {
             var args = Environment.GetCommandLineArgs();
-            this._fpfc = args.Any(x => x.Contains("fpfc"));
+            this._fpfc = args.Contains("fpfc");
 
             this._platformHelper.GetNodePose(XRNode.Head, 0, out var hmdpos, out _);
             this._prevHMDPosition = hmdpos;


### PR DESCRIPTION
Fixed #5 

## Summary
`_fpfc`族からの防衛

## Changes
- `fpfc` オプションの検出ロジックを部分一致から完全一致に修正

## Tests
- 実行時引数を全く付与しない状態で HDT が正常動作することを確認
- `_fpfc` オプションを付与した状態で HDT が正常動作することを確認
- `fpfc` オプションを付与した状態で `fpfc` モードが正常に検出されることを確認

## Notes
`_fpfc`族うせやろ...